### PR TITLE
fix unmatch python version

### DIFF
--- a/exercises/creating_python_actions/exercise.js
+++ b/exercises/creating_python_actions/exercise.js
@@ -6,7 +6,7 @@ exercise.requireSubmission = false
 exercise.addVerifyProcessor(function (cb) {
   shell.exec('wsk action get hello-world-python', {silent: true}, (code, stdout, stderr) => {
     const exists = (code === 0)
-    const uses_python = (stdout.match('"kind": "python"'))
+    const uses_python = (stdout.match(/\"kind\": \"python:?[\d.]+?"/))
 
     const success = exists && !!uses_python
     if (success) {
@@ -38,7 +38,7 @@ exercise.addVerifyProcessor(function (cb) {
 exercise.addVerifyProcessor(function (cb) {
   shell.exec('wsk action get london-location-python', {silent: true}, (code, stdout, stderr) => {
     const exists = (code === 0)
-    const uses_python = (stdout.match('"kind": "python"'))
+    const uses_python = (stdout.match(/\"kind\": \"python:?[\d.]+?"/))
 
     const success = exists && !!uses_python
     if (success) {


### PR DESCRIPTION
When I use `wsk action get hello-world-python` , the response returned
`{
    "kind": "python:2",
    ...
  }`
instead of 
`{
    "kind": "python",
    ...
  }`
So I think that should use regex for match language runtime version 'll better than.