### PR TITLE
Fix exercise 'binding triggers to actions' due api changes

### DIFF
--- a/exercises/binding_triggers_to_actions/exercise.js
+++ b/exercises/binding_triggers_to_actions/exercise.js
@@ -62,7 +62,7 @@ exercise.addVerifyProcessor(function (cb) {
     if (exists) {
       this.emit('pass', 'OpenWhisk Rule first-trigger-rule exists')
       const rule = JSON.parse(stdout.match(/{[^]*$/)[0])
-      if (rule.trigger === 'rule-trigger') {
+      if (rule.trigger.name === 'rule-trigger') {
         this.emit('pass', 'OpenWhisk Rule first-trigger-rule bound to correct trigger')
       } else {
         this.emit('fail', 'OpenWhisk Rule first-trigger-rule bound to wrong trigger')
@@ -81,7 +81,7 @@ exercise.addVerifyProcessor(function (cb) {
     if (exists) {
       this.emit('pass', 'OpenWhisk Rule second-trigger-rule exists')
       const rule = JSON.parse(stdout.match(/{[^]*$/)[0])
-      if (rule.trigger === 'rule-trigger') {
+      if (rule.trigger.name === 'rule-trigger') {
         this.emit('pass', 'OpenWhisk Rule second-trigger-rule bound to correct trigger')
       } else {
         this.emit('fail', 'OpenWhisk Rule second-trigger-rule bound to wrong trigger')


### PR DESCRIPTION
Fix due changes in the api.

Using client `2017-07-12T20:09:28+00:00`:

```
$ wsk rule update first-trigger-rule rule-trigger first-trigger-action
ok: updated rule first-trigger-rule
$ wsk rule get first-trigger-rule
ok: got rule first-trigger-rule
{
    "namespace": "---",
    "name": "first-trigger-rule",
    "version": "0.0.1",
    "status": "active",
    "trigger": {
        "name": "rule-trigger",
        "path": "---"
    },
    "action": {
        "name": "first-trigger-action",
        "path": "---"
    },
    "publish": false
}
```